### PR TITLE
Fixed cache when there is more than one mod_google_calendar on the site.

### DIFF
--- a/src/mod_google_calendar.php
+++ b/src/mod_google_calendar.php
@@ -15,14 +15,15 @@ try
 	$helper = new ModGoogleCalendarHelper($params);
 
 	// Setup joomla cache
-	$cache = JFactory::getCache();
+	$cache = JFactory::getCache('mod_google_calendar');
 	$cache->setCaching(true);
 	$cache->setLifeTime($params->get('api_cache_time', 60));
 
 	// Get the next events
 	$events = $cache->call(
 		array($helper, 'nextEvents'),
-		(int) $params->get('max_list_events', 5)
+		(int) $params->get('max_list_events', 5),
+		$module->id
 	);
 
 	// Get the Layout


### PR DESCRIPTION
Hi,
I use several copy of mod_google_calendar on my site with a different Google calendar ID and API Key configured for each module.
In order to keep a cache of ModGoogleCalendarHelper::nextEvents call for each module I slightly modified your code. Otherwise, all modules call the same cache and display the same events.

For a live demo check <https://inciudades.cuaad.udg.mx>, <https://inciudades.cuaad.udg.mx/mpegpau>, <https://inciudades.cuaad.udg.mx/dcts>.

Thanks for sharing your code.